### PR TITLE
[WP-3528] Add a listReadOnlyMode to selector

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -49,7 +49,6 @@ var StatesField = React.createClass({
 		});
 	},
 	focusStateSelect: function() {
-		console.log(this.refs);
 		this.refs.stateSelect.focus();
 	},
 	render: function() {

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -7,7 +7,7 @@ var React = require('react'),
 	Select = require('react-select');
 
 var STATES = require('./data/states');
-
+var listReadOnly = false;
 function logChange(value) {
 	console.log('Select value changed: ' + value);
 }
@@ -49,6 +49,7 @@ var StatesField = React.createClass({
 		});
 	},
 	focusStateSelect: function() {
+		console.log(this.refs);
 		this.refs.stateSelect.focus();
 	},
 	render: function() {
@@ -170,6 +171,10 @@ var SelectedValuesField = React.createClass({
 });
 
 var ListSelectField = React.createClass({
+	toggleEdit: function() {
+		listReadOnly = !listReadOnly;
+		this.refs.listSelect.toggleEdit(listReadOnly);
+	},
 	render: function() {
 		var ops = [
 			{ label: 'Chocolate', value: 'chocolate' },
@@ -183,10 +188,15 @@ var ListSelectField = React.createClass({
 			<div>
 				<label>{this.props.label}</label>
 				<Select
+					ref="listSelect"
 					list={true}
 					placeholder="Select your favourite(s)"
 					options={ops}
-					onChange={logChange} />
+					onChange={logChange}
+					listReadOnlyMode={listReadOnly}/>
+				<div className="form-toolbar">
+					<button type="button" onClick={this.toggleEdit}>Toggle read only</button>
+				</div>
 			</div>
 		);
 	}

--- a/src/Select.js
+++ b/src/Select.js
@@ -688,7 +688,6 @@ var Select = React.createClass({
 						props[key] = val[key];
 					}
 				}
-				// Aqui pone los values
 				value.push(<Value {...props} />);
 			}, this);
 		}

--- a/src/Select.js
+++ b/src/Select.js
@@ -89,7 +89,7 @@ var Select = React.createClass({
 			isFocused: false,
 			isOpen: false,
 			isLoading: false,
-			onReadOnlyMode: this.props.listReadOnlyMode
+			isReadOnly: this.props.listReadOnlyMode
 		};
 	},
 
@@ -186,7 +186,7 @@ var Select = React.createClass({
 
 	toggleEdit : function(readOnly) {
 		this.setState({
-			onReadOnlyMode : readOnly
+			isReadOnly : readOnly
 		});
 	},
 
@@ -681,7 +681,7 @@ var Select = React.createClass({
 					optionLabelClick: !!this.props.onOptionLabelClick,
 					onOptionLabelClick: this.handleOptionLabelClick.bind(this, val),
 					onRemove: this.removeValue.bind(this, val),
-					deletable: !this.state.onReadOnlyMode
+					deletable: !this.state.isReadOnly
 				};
 				for (var key in val) {
 					if (val.hasOwnProperty(key)) {
@@ -741,7 +741,7 @@ var Select = React.createClass({
 		}
 
 		if(this.props.list) {
-			if(!this.state.onReadOnlyMode)
+			if(!this.state.isReadOnly)
 			{
 				var selector = (<div className="dropdown">
 					<input type="hidden" ref="value" name={this.props.name} value={this.state.value}

--- a/src/Select.js
+++ b/src/Select.js
@@ -35,6 +35,7 @@ var Select = React.createClass({
 		matchPos: React.PropTypes.string,          // (any|start) match the start or entire string when filtering
 		matchProp: React.PropTypes.string,         // (any|label|value) which option property to filter on
 		inputProps: React.PropTypes.object,        // custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
+		listReadOnlyMode: React.PropTypes.bool,	   // Non editable list mode currently implemented for List select only
 
 		/*
 		* Allow user to make option label clickable. When this handler is defined we should
@@ -67,6 +68,7 @@ var Select = React.createClass({
 			matchPos: 'any',
 			matchProp: 'any',
 			inputProps: {},
+			listReadOnlyMode: false,
 
 			onOptionLabelClick: undefined
 		};
@@ -86,7 +88,8 @@ var Select = React.createClass({
 			options: this.props.options,
 			isFocused: false,
 			isOpen: false,
-			isLoading: false
+			isLoading: false,
+			onReadOnlyMode: this.props.listReadOnlyMode
 		};
 	},
 
@@ -179,6 +182,12 @@ var Select = React.createClass({
 
 	focus: function() {
 		this.getInputNode().focus();
+	},
+
+	toggleEdit : function(readOnly) {
+		this.setState({
+			onReadOnlyMode : readOnly
+		});
 	},
 
 	clickedOutsideElement: function(element, event) {
@@ -671,13 +680,15 @@ var Select = React.createClass({
 					key: this.getIdentifier(val),
 					optionLabelClick: !!this.props.onOptionLabelClick,
 					onOptionLabelClick: this.handleOptionLabelClick.bind(this, val),
-					onRemove: this.removeValue.bind(this, val)
+					onRemove: this.removeValue.bind(this, val),
+					deletable: !this.state.onReadOnlyMode
 				};
 				for (var key in val) {
 					if (val.hasOwnProperty(key)) {
 						props[key] = val[key];
 					}
 				}
+				// Aqui pone los values
 				value.push(<Value {...props} />);
 			}, this);
 		}
@@ -731,19 +742,26 @@ var Select = React.createClass({
 		}
 
 		if(this.props.list) {
-			return (
-				<div ref="wrapper" className={selectClass}>
-					<div className="dropdown">
-						<input type="hidden" ref="value" name={this.props.name} value={this.state.value} disabled={this.props.disabled} />
-						<div className="Select-control" ref="control" onKeyDown={this.handleKeyDown} onMouseDown={this.handleMouseDown} onTouchEnd={this.handleMouseDown}>
+			if(!this.state.onReadOnlyMode)
+			{
+				var selector = (<div className="dropdown">
+					<input type="hidden" ref="value" name={this.props.name} value={this.state.value}
+						   disabled={this.props.disabled}/>
+
+					<div className="Select-control" ref="control" onKeyDown={this.handleKeyDown}
+						 onMouseDown={this.handleMouseDown} onTouchEnd={this.handleMouseDown}>
 						{placeholder}
 						{input}
-							<span className="Select-arrow" onMouseDown={this.toggleDropdown}/>
+						<span className="Select-arrow" onMouseDown={this.toggleDropdown}/>
 						{loading}
-						</div>
-					{menu}
 					</div>
-				{value}
+					{menu}
+				</div>);
+			}
+			return (
+				<div ref="wrapper" className={selectClass}>
+					{selector}
+					{value}
 				</div>
 			);
 		}

--- a/src/Value.js
+++ b/src/Value.js
@@ -5,7 +5,8 @@ var Option = React.createClass({
 	displayName: 'Value',
 
 	propTypes: {
-		label: React.PropTypes.string.isRequired
+		label: React.PropTypes.string.isRequired,
+		deletable: React.PropTypes.bool
 	},
 
 	blockEvent: function(event) {
@@ -25,13 +26,17 @@ var Option = React.createClass({
 				</a>
 			);
 		}
-
+		
+		if(this.props.deletable){
+			var removeIcon = (<span className="Select-item-icon"
+								onMouseDown={this.blockEvent}
+								onClick={this.props.onRemove}
+								onTouchEnd={this.props.onRemove}>&times;</span>);
+		}
+		
 		return (
 			<div className="Select-item">
-				<span className="Select-item-icon"
-					onMouseDown={this.blockEvent}
-					onClick={this.props.onRemove}
-					onTouchEnd={this.props.onRemove}>&times;</span>
+				{removeIcon}
 				<span className="Select-item-label">{label}</span>
 			</div>
 		);


### PR DESCRIPTION
:warning:  WIP :warning: 
Useful for [WP-3528](http://jira.thewizeline.com/browse/WP-3528).
![demo](https://api.monosnap.com/rpc/file/download?id=8Omwh1D2oaP0QqWT7irJ0vUM2SgLPf)

@tkreis, @diegoglezs, @albertein PR.

TODO: Make the selected options list appear above the selector.
