### PR TITLE
[WP-3529] Add max selection options

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -288,8 +288,8 @@ var Select = React.createClass({
 	},
 	
 	replaceValue: function(value) {
-		var poped_values = this.state.values.slice(0, this.state.values.length - 1);
-		this.setValue(poped_values.concat(value));
+		var remainingValues = this.state.values.slice(0, this.state.values.length - 1);
+		this.setValue(remainingValues.concat(value));
 	},
 
 	popValue: function() {

--- a/src/Select.js
+++ b/src/Select.js
@@ -329,14 +329,14 @@ var Select = React.createClass({
 			return;
 		}
 		
-		if (this.props.maxMultiSelection > 0 && this.state.isOpen) {
-			if (this.state.values.length + 1 > this.props.maxMultiSelection && this.props.replaceIfMax) {
-				this.closeDropdown();
-				return;
-			} else if (this.state.values.length + 1 == this.props.maxMultiSelection) {
-				this.closeDropdown();
-				return;
-			}
+		var isMultiLimitedAndOpen = this.props.maxMultiSelection > 0 && this.state.isOpen;
+		var replaceIfMaxValueReached = this.state.values.length >= this.props.maxMultiSelection && this.props.replaceIfMax;
+		// This event is called before the value is added to the state (just after a click on an option), so we count ahead
+		var willReachMaxValue = this.state.values.length + 1 == this.props.maxMultiSelection;
+		
+		if (isMultiLimitedAndOpen && (replaceIfMaxValueReached || willReachMaxValue)) {
+			this.closeDropdown();
+			return;
 		}
 
 		event.stopPropagation();

--- a/src/Select.js
+++ b/src/Select.js
@@ -271,10 +271,6 @@ var Select = React.createClass({
 		if (this.props.maxMultiSelection > 0) {
 			if (this.state.values.length +1 > this.props.maxMultiSelection && this.props.replaceIfMax) {
 				this.replaceValue(value);
-				this.toggleDropdown()
-			} else if (this.state.values.length + 1 == this.props.maxMultiSelection) {
-				this.addValue(value);
-				this.toggleDropdown()
 			} else if (this.state.values.length + 1 <= this.props.maxMultiSelection) {
 				this.addValue(value);
 			}
@@ -331,6 +327,16 @@ var Select = React.createClass({
 		// button, or if the component is disabled, ignore it.
 		if (this.props.disabled || (event.type === 'mousedown' && event.button !== 0)) {
 			return;
+		}
+		
+		if (this.props.maxMultiSelection > 0 && this.state.isOpen) {
+			if (this.state.values.length + 1 > this.props.maxMultiSelection && this.props.replaceIfMax) {
+				this.closeDropdown();
+				return;
+			} else if (this.state.values.length + 1 == this.props.maxMultiSelection) {
+				this.closeDropdown();
+				return;
+			}
 		}
 
 		event.stopPropagation();
@@ -673,6 +679,12 @@ var Select = React.createClass({
 			event.stopPropagation();
 			event.preventDefault();
 		}
+	},
+	
+	closeDropdown: function() {
+		this.setState({
+			isOpen: false
+		}, this._unbindCloseMenuIfClickedOutside);
 	},
 
 	handleOptionLabelClick: function (value, event) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -36,6 +36,8 @@ var Select = React.createClass({
 		matchProp: React.PropTypes.string,         // (any|label|value) which option property to filter on
 		inputProps: React.PropTypes.object,        // custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
 		listReadOnlyMode: React.PropTypes.bool,	   // Non editable list mode currently implemented for List select only
+		maxMultiSelection: React.PropTypes.number, // Number of maximum allowed options to select on multi mode
+		replaceIfMax: React.PropTypes.bool,		   // Replace selected values if max selection number is reached
 
 		/*
 		* Allow user to make option label clickable. When this handler is defined we should
@@ -69,6 +71,8 @@ var Select = React.createClass({
 			matchProp: 'any',
 			inputProps: {},
 			listReadOnlyMode: false,
+			maxMultiSelection: -1,
+			replaceIfMax: false,
 
 			onOptionLabelClick: undefined
 		};
@@ -258,13 +262,34 @@ var Select = React.createClass({
 		if (!this.props.multi && !this.props.list) {
 			this.setValue(value);
 		} else if (value) {
-			this.addValue(value);
+			this.addMultiSelectValue(value);
 		}
 		this._unbindCloseMenuIfClickedOutside();
 	},
-
+	
+	addMultiSelectValue: function(value) {
+		if (this.props.maxMultiSelection > 0) {
+			if (this.state.values.length +1 > this.props.maxMultiSelection && this.props.replaceIfMax) {
+				this.replaceValue(value);
+				this.toggleDropdown()
+			} else if (this.state.values.length + 1 == this.props.maxMultiSelection) {
+				this.addValue(value);
+				this.toggleDropdown()
+			} else if (this.state.values.length + 1 <= this.props.maxMultiSelection) {
+				this.addValue(value);
+			}
+		} else if (this.props.maxMultiSelection != 0) {
+			this.addValue(value);
+		}
+	},
+	
 	addValue: function(value) {
 		this.setValue(this.state.values.concat(value));
+	},
+	
+	replaceValue: function(value) {
+		var poped_values = this.state.values.slice(0, this.state.values.length - 1);
+		this.setValue(poped_values.concat(value));
 	},
 
 	popValue: function() {


### PR DESCRIPTION
This adds options to define a maximum number of selected options, and replace them if you get pass the limit.

Required for [WP-3529](http://jira.thewizeline.com/browse/WP-3529) and single select custom field support.

![This is not even a loop](https://api.monosnap.com/rpc/file/download?id=ghzHJMKY3OVCXWB4RczAEHbLXbAzfI)

@tkreis @diegoglezs @carlosyslas PR
